### PR TITLE
[Fix] loadPosts Action 쿼리문 수정, 인피니트 스크롤링 중복요청 취소 처리

### DIFF
--- a/toolkit/front/actions/post.js
+++ b/toolkit/front/actions/post.js
@@ -7,8 +7,19 @@ axios.defaults.baseURL = backendUrl;
 axios.defaults.withCredentials = true; // front, backend 간 쿠키공유
 
 export const loadPosts = createAsyncThunk('post/loadPosts', async (data) => {
-  const response = await axios.get(`/posts?last=${data?.lastId || 0}`);
+  const response = await axios.get(`/posts?lastId=${data?.lastId || 0}`);
   return response.data;
+},
+{
+  condition: (data, { getState }) => {
+    const { post } = getState();
+
+    if (post.loadPostsLoading) {
+      // console.warn('중복 요청 취소');
+      return false;
+    }
+    return true;
+  },
 });
 
 export const addPost = createAsyncThunk('post/addPost', async (data, thunkAPI) => {


### PR DESCRIPTION
@ZeroCho 
안녕하세요 제로초님. 노드버드 강의를 수강하면서 리덕스 툴킷도 적용을 해보면서,
코드를 보다가 에러를 발견해서 수정건의 해봅니다.
revised 브랜치에 하려고 했지만, 업데이트 날짜를 보니 master브랜치가 맞는거 같아 master브랜치에 pull request를 하게 되었습니다.

### issue
loadPosts Action에 대해서 입니다.
redux toolkit이 적용된 프로젝트를 실행시키면, 계속 같은 데이터만 넘어오는 걸 알 수 있는데,
![1](https://user-images.githubusercontent.com/65812122/159169305-eba69b2a-09b0-48be-844f-a7168fead640.PNG)
![image](https://user-images.githubusercontent.com/65812122/159172476-15ad3d22-9970-448d-87c0-db48c9d16a56.png)

이 문제는 해당 코드에서 쿼리문에 /posts?last 라고 되어 있기에 lastId 요청이 계속 0으로 가던 문제였던 것으로 발견되어
위와 같이 /posts?lastId로 변경하였습니다.


이렇게 수정을 하면 다음 id 게시물들을 불러올 수 있지만, 엄청 빠른속도로 스크롤링을 하다보면 여전히 인피니트 스크롤링에서는 hasMorePosts 와 lodPostsLoading의 조건을 걸어놔도 같은 요청이 가게 됩니다. 
![2](https://user-images.githubusercontent.com/65812122/159169340-42bf30fe-b840-4b14-8a67-b9c45d5c8f09.PNG)

이는, redux-toolkit의 cancellation쪽의 공식문서를 보면서 해답을 얻을 수 있었고,
 loadPosts Action에 condition을 거는 방법으로 해결할 수 있습니다.
![3](https://user-images.githubusercontent.com/65812122/159169545-e698f67f-7377-4287-a4c8-09e316a9dd0b.PNG)
![4](https://user-images.githubusercontent.com/65812122/159169549-61d350b6-85c2-4b24-b127-ae2bb6ca0696.PNG)
