### PR TITLE
Fix: Reset PostCardContent Edit TextArea on Cancel

### DIFF
--- a/ch7/front/components/PostCardContent.js
+++ b/ch7/front/components/PostCardContent.js
@@ -19,6 +19,11 @@ const PostCardContent = ({ postData, editMode, onChangePost, onCancelUpdate }) =
     setEditText(e.target.value);
   });
 
+  const onClickCancel = useCallback(() => {
+    setEditText(postData);
+    onCancelUpdate();
+  });
+
   return ( // 첫 번째 게시글 #해시태그 #해시태그
     <div>
       {editMode
@@ -27,7 +32,7 @@ const PostCardContent = ({ postData, editMode, onChangePost, onCancelUpdate }) =
             <TextArea value={editText} onChange={onChangeText} />
             <Button.Group>
               <Button loading={updatePostLoading} onClick={onChangePost(editText)}>수정</Button>
-              <Button type="danger" onClick={onCancelUpdate}>취소</Button>
+              <Button type="danger" onClick={onClickCancel}>취소</Button>
             </Button.Group>
           </>
         )

--- a/https/front/components/PostCardContent.js
+++ b/https/front/components/PostCardContent.js
@@ -19,6 +19,11 @@ const PostCardContent = ({ postData, editMode, onChangePost, onCancelUpdate }) =
     setEditText(e.target.value);
   });
 
+  const onClickCancel = useCallback(() => {
+    setEditText(postData);
+    onCancelUpdate();
+  });
+
   return ( // 첫 번째 게시글 #해시태그 #해시태그
     <div>
       {editMode
@@ -27,7 +32,7 @@ const PostCardContent = ({ postData, editMode, onChangePost, onCancelUpdate }) =
             <TextArea value={editText} onChange={onChangeText} />
             <Button.Group>
               <Button loading={updatePostLoading} onClick={onChangePost(editText)}>수정</Button>
-              <Button type="danger" onClick={onCancelUpdate}>취소</Button>
+              <Button type="danger" onClick={onClickCancel}>취소</Button>
             </Button.Group>
           </>
         )

--- a/intersection/front/components/PostCardContent.js
+++ b/intersection/front/components/PostCardContent.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 
 const { TextArea } = Input;
-function PostCardContent({ postData, editMode, onChangePost, onCancelUpdate }) {
+const PostCardContent = ({ postData, editMode, onChangePost, onCancelUpdate }) => {
   const { updatePostLoading, updatePostDone } = useSelector((state) => state.post);
   const [editText, setEditText] = useState(postData);
 
@@ -19,6 +19,11 @@ function PostCardContent({ postData, editMode, onChangePost, onCancelUpdate }) {
     setEditText(e.target.value);
   });
 
+  const onClickCancel = useCallback(() => {
+    setEditText(postData);
+    onCancelUpdate();
+  });
+
   return ( // 첫 번째 게시글 #해시태그 #해시태그
     <div>
       {editMode
@@ -27,7 +32,7 @@ function PostCardContent({ postData, editMode, onChangePost, onCancelUpdate }) {
             <TextArea value={editText} onChange={onChangeText} />
             <Button.Group>
               <Button loading={updatePostLoading} onClick={onChangePost(editText)}>수정</Button>
-              <Button type="danger" onClick={onCancelUpdate}>취소</Button>
+              <Button type="danger" onClick={onClickCancel}>취소</Button>
             </Button.Group>
           </>
         )
@@ -39,7 +44,7 @@ function PostCardContent({ postData, editMode, onChangePost, onCancelUpdate }) {
         })}
     </div>
   );
-}
+};
 
 PostCardContent.propTypes = {
   postData: PropTypes.string.isRequired,

--- a/react-query/front/components/PostCardContent.tsx
+++ b/react-query/front/components/PostCardContent.tsx
@@ -30,6 +30,11 @@ const PostCardContent: VFC<Props> = ({ postData, editMode, onChangePost, onCance
     setEditText(e.target.value);
   }, []);
 
+  const onClickCancel = useCallback(() => {
+    setEditText(postData);
+    onCancelUpdate();
+  });
+
   return (
     // 첫 번째 게시글 #해시태그 #해시태그
     <div>
@@ -40,7 +45,7 @@ const PostCardContent: VFC<Props> = ({ postData, editMode, onChangePost, onCance
             <Button loading={loading} onClick={onChange}>
               수정
             </Button>
-            <Button danger onClick={onCancelUpdate}>
+            <Button danger onClick={onClickCancel}>
               취소
             </Button>
           </Button.Group>

--- a/toolkit/front/components/PostCardContent.js
+++ b/toolkit/front/components/PostCardContent.js
@@ -19,6 +19,11 @@ const PostCardContent = ({ postData, editMode, onChangePost, onCancelUpdate }) =
     setEditText(e.target.value);
   });
 
+  const onClickCancel = useCallback(() => {
+    setEditText(postData);
+    onCancelUpdate();
+  });
+
   return ( // 첫 번째 게시글 #해시태그 #해시태그
     <div>
       {editMode
@@ -27,7 +32,7 @@ const PostCardContent = ({ postData, editMode, onChangePost, onCancelUpdate }) =
             <TextArea value={editText} onChange={onChangeText} />
             <Button.Group>
               <Button loading={updatePostLoading} onClick={onChangePost(editText)}>수정</Button>
-              <Button type="danger" onClick={onCancelUpdate}>취소</Button>
+              <Button type="danger" onClick={onClickCancel}>취소</Button>
             </Button.Group>
           </>
         )


### PR DESCRIPTION
Post 수정을 취소하는 경우, editText가 원래의 값으로 리셋되지 않아 다시 수정 버튼 클릭시 이전 수정 정보가 남아있는 문제 수정